### PR TITLE
Rename GAV + packages to replace ch.vorburger by org.lastnpe

### DIFF
--- a/examples/maven/parent/pom.xml
+++ b/examples/maven/parent/pom.xml
@@ -116,13 +116,13 @@
       <version>1.7.21</version>
     </dependency>
     <dependency>
-      <groupId>ch.vorburger.null.eea</groupId>
+      <groupId>org.lastnpe.eea</groupId>
       <artifactId>jdk-eea</artifactId>
       <version>1.0.0-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>ch.vorburger.null.eea</groupId>
+      <groupId>org.lastnpe.eea</groupId>
       <artifactId>slf4j-api-eea</artifactId>
       <version>1.0.0-SNAPSHOT</version>
       <scope>provided</scope>

--- a/libraries/guava/pom.xml
+++ b/libraries/guava/pom.xml
@@ -5,12 +5,11 @@
   <!-- TODO This file should be auto-generated from a template, based on directory, not hand-maintained -->
 
   <parent>
-    <groupId>ch.vorburger.null</groupId>
+    <groupId>org.lastnpe.eea</groupId>
     <artifactId>eea-parent</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
 
-  <groupId>ch.vorburger.null.eea</groupId>
   <artifactId>guava-eea</artifactId>
 
   <!-- Do NOT use a <version> of the JAR for which this is an EEA here,

--- a/libraries/java/pom.xml
+++ b/libraries/java/pom.xml
@@ -5,12 +5,11 @@
   <!-- TODO This file should be auto-generated from a template, based on directory, not hand-maintained -->
 
   <parent>
-    <groupId>ch.vorburger.null</groupId>
+    <groupId>org.lastnpe.eea</groupId>
     <artifactId>eea-parent</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
 
-  <groupId>ch.vorburger.null.eea</groupId>
   <artifactId>jdk-eea</artifactId>
 
   <!-- Do NOT use a <version> of the JAR for which this is an EEA here,

--- a/libraries/mockito/pom.xml
+++ b/libraries/mockito/pom.xml
@@ -5,12 +5,11 @@
   <!-- TODO This file should be auto-generated from a template, based on directory, not hand-maintained -->
 
   <parent>
-    <groupId>ch.vorburger.null</groupId>
+    <groupId>org.lastnpe.eea</groupId>
     <artifactId>eea-parent</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
 
-  <groupId>ch.vorburger.null.eea</groupId>
   <artifactId>mockito-eea</artifactId>
 
   <!-- Do NOT use a <version> of the JAR for which this is an EEA here,

--- a/libraries/pom.xml
+++ b/libraries/pom.xml
@@ -2,20 +2,20 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>ch.vorburger.null</groupId>
+  <groupId>org.lastnpe.eea</groupId>
   <artifactId>eea-parent</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Eclipse External null Annotations (EEA)</name>
   <description>JARs of *.eea for the JDK and common Java libraries</description>
-  <url>https://github.com/vorburger/eclipse-null-eea-augments</url>
+  <url>https://lastnpe.org</url>
   <inceptionYear>2016</inceptionYear>
 
   <scm>
-    <connection>https://github.com/vorburger/eclipse-null-eea-augments.git</connection>
-    <developerConnection>scm:git:git@github.comgit:vorburger/eclipse-null-eea-augments.git</developerConnection>
-    <url>https://github.com/vorburger/eclipse-null-eea-augments</url>
+    <connection>https://github.com/lastnpe/eclipse-null-eea-augments.git</connection>
+    <developerConnection>scm:git:git@github.com:lastnpe/eclipse-null-eea-augments.git</developerConnection>
+    <url>https://github.com/lastnpe/eclipse-null-eea-augments</url>
     <tag>HEAD</tag>
   </scm>
 
@@ -42,7 +42,7 @@
   </developers>
   <contributors>
     <contributor>
-      <name>Please consult see https://github.com/vorburger/eclipse-null-eea-augments/graphs/contributors</name>
+      <name>Please see https://github.com/lastnpe/eclipse-null-eea-augments/graphs/contributors</name>
     </contributor>
   </contributors>
 

--- a/libraries/slf4j-api/pom.xml
+++ b/libraries/slf4j-api/pom.xml
@@ -5,12 +5,11 @@
   <!-- TODO This file should be auto-generated from a template, based on directory, not hand-maintained -->
 
   <parent>
-    <groupId>ch.vorburger.null</groupId>
+    <groupId>org.lastnpe.eea</groupId>
     <artifactId>eea-parent</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
 
-  <groupId>ch.vorburger.null.eea</groupId>
   <artifactId>slf4j-api-eea</artifactId>
 
   <!-- Do NOT use a <version> of the JAR for which this is an EEA here,


### PR DESCRIPTION
only libraries, not yet example (I'm short on time)

Fixes https://github.com/lastnpe/eclipse-null-eea-augments/issues/1