### PR TITLE
add annotations for Java 8 classes

### DIFF
--- a/libraries/java/java/io/File.eea
+++ b/libraries/java/java/io/File.eea
@@ -1,0 +1,4 @@
+class java/io/File
+getAbsolutePath
+ ()Ljava/lang/String;
+ ()L1java/lang/String;

--- a/libraries/java/java/lang/Class.eea
+++ b/libraries/java/java/lang/Class.eea
@@ -1,0 +1,4 @@
+class java/lang/Class
+getAnnotation
+ <A::Ljava/lang/annotation/Annotation;>(Ljava/lang/Class<TA;>;)TA;
+ <A::Ljava/lang/annotation/Annotation;>(Ljava/lang/Class<TA;>;)T0A;

--- a/libraries/java/java/lang/Integer.eea
+++ b/libraries/java/java/lang/Integer.eea
@@ -1,0 +1,4 @@
+class java/lang/Integer
+toString
+ (I)Ljava/lang/String;
+ (I)L1java/lang/String;

--- a/libraries/java/java/lang/Object.eea
+++ b/libraries/java/java/lang/Object.eea
@@ -2,3 +2,9 @@ class java/lang/Object
 equals
  (Ljava/lang/Object;)Z
  (L0java/lang/Object;)Z
+getClass
+ ()Ljava/lang/Class<*>;
+ ()L1java/lang/Class<*1>;
+toString
+ ()Ljava/lang/String;
+ ()L1java/lang/String;

--- a/libraries/java/java/lang/String.eea
+++ b/libraries/java/java/lang/String.eea
@@ -1,4 +1,13 @@
 class java/lang/String
+format
+ (Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;
+ (Ljava/lang/String;[Ljava/lang/Object;)L1java/lang/String;
+replace
+ (CC)Ljava/lang/String;
+ (CC)L1java/lang/String;
 toLowerCase
  ()Ljava/lang/String;
  ()L1java/lang/String;
+valueOf
+ (J)Ljava/lang/String;
+ (J)L1java/lang/String;

--- a/libraries/java/java/lang/StringBuilder.eea
+++ b/libraries/java/java/lang/StringBuilder.eea
@@ -1,0 +1,4 @@
+class java/lang/StringBuilder
+toString
+ ()Ljava/lang/String;
+ ()L1java/lang/String;

--- a/libraries/java/java/util/Collection.eea
+++ b/libraries/java/java/util/Collection.eea
@@ -1,0 +1,7 @@
+class java/util/Collection
+parallelStream
+ ()Ljava/util/stream/Stream<TE;>;
+ ()Ljava/util/stream/Stream<T+E;>;
+stream
+ ()Ljava/util/stream/Stream<TE;>;
+ ()Ljava/util/stream/Stream<T+E;>;

--- a/libraries/java/java/util/Collections.eea
+++ b/libraries/java/java/util/Collections.eea
@@ -1,4 +1,103 @@
 class java/util/Collections
+emptyEnumeration
+ <T:Ljava/lang/Object;>()Ljava/util/Enumeration<TT;>;
+ <T:Ljava/lang/Object;>()L1java/util/Enumeration<TT;>;
+emptyIterator
+ <T:Ljava/lang/Object;>()Ljava/util/Iterator<TT;>;
+ <T:Ljava/lang/Object;>()L1java/util/Iterator<TT;>;
+emptyList
+ <T:Ljava/lang/Object;>()Ljava/util/List<TT;>;
+ <T:Ljava/lang/Object;>()L1java/util/List<TT;>;
+emptyListIterator
+ <T:Ljava/lang/Object;>()Ljava/util/ListIterator<TT;>;
+ <T:Ljava/lang/Object;>()L1java/util/ListIterator<TT;>;
 emptyMap
  <K:Ljava/lang/Object;V:Ljava/lang/Object;>()Ljava/util/Map<TK;TV;>;
  <K:Ljava/lang/Object;V:Ljava/lang/Object;>()L1java/util/Map<TK;TV;>;
+emptyNavigableMap
+ <K:Ljava/lang/Object;V:Ljava/lang/Object;>()Ljava/util/NavigableMap<TK;TV;>;
+ <K:Ljava/lang/Object;V:Ljava/lang/Object;>()L1java/util/NavigableMap<TK;TV;>;
+emptyNavigableSet
+ <E:Ljava/lang/Object;>()Ljava/util/NavigableSet<TE;>;
+ <E:Ljava/lang/Object;>()L1java/util/NavigableSet<TE;>;
+emptySet
+ <T:Ljava/lang/Object;>()Ljava/util/Set<TT;>;
+ <T:Ljava/lang/Object;>()L1java/util/Set<TT;>;
+emptySortedMap
+ <K:Ljava/lang/Object;V:Ljava/lang/Object;>()Ljava/util/SortedMap<TK;TV;>;
+ <K:Ljava/lang/Object;V:Ljava/lang/Object;>()L1java/util/SortedMap<TK;TV;>;
+emptySortedSet
+ <E:Ljava/lang/Object;>()Ljava/util/SortedSet<TE;>;
+ <E:Ljava/lang/Object;>()L1java/util/SortedSet<TE;>;
+singleton
+ <T:Ljava/lang/Object;>(TT;)Ljava/util/Set<TT;>;
+ <T:Ljava/lang/Object;>(TT;)L1java/util/Set<TT;>;
+singletonIterator
+ <E:Ljava/lang/Object;>(TE;)Ljava/util/Iterator<TE;>;
+ <E:Ljava/lang/Object;>(TE;)L1java/util/Iterator<TE;>;
+singletonList
+ <T:Ljava/lang/Object;>(TT;)Ljava/util/List<TT;>;
+ <T:Ljava/lang/Object;>(TT;)L1java/util/List<TT;>;
+singletonMap
+ <K:Ljava/lang/Object;V:Ljava/lang/Object;>(TK;TV;)Ljava/util/Map<TK;TV;>;
+ <K:Ljava/lang/Object;V:Ljava/lang/Object;>(TK;TV;)L1java/util/Map<TK;TV;>;
+singletonSpliterator
+ <T:Ljava/lang/Object;>(TT;)Ljava/util/Spliterator<TT;>;
+ <T:Ljava/lang/Object;>(TT;)L1java/util/Spliterator<TT;>;
+synchronizedCollection
+ <T:Ljava/lang/Object;>(Ljava/util/Collection<TT;>;)Ljava/util/Collection<TT;>;
+ <T:Ljava/lang/Object;>(Ljava/util/Collection<TT;>;)L1java/util/Collection<TT;>;
+synchronizedCollection
+ <T:Ljava/lang/Object;>(Ljava/util/Collection<TT;>;Ljava/lang/Object;)Ljava/util/Collection<TT;>;
+ <T:Ljava/lang/Object;>(Ljava/util/Collection<TT;>;Ljava/lang/Object;)L1java/util/Collection<TT;>;
+synchronizedList
+ <T:Ljava/lang/Object;>(Ljava/util/List<TT;>;)Ljava/util/List<TT;>;
+ <T:Ljava/lang/Object;>(Ljava/util/List<TT;>;)L1java/util/List<TT;>;
+synchronizedList
+ <T:Ljava/lang/Object;>(Ljava/util/List<TT;>;Ljava/lang/Object;)Ljava/util/List<TT;>;
+ <T:Ljava/lang/Object;>(Ljava/util/List<TT;>;Ljava/lang/Object;)L1java/util/List<TT;>;
+synchronizedMap
+ <K:Ljava/lang/Object;V:Ljava/lang/Object;>(Ljava/util/Map<TK;TV;>;)Ljava/util/Map<TK;TV;>;
+ <K:Ljava/lang/Object;V:Ljava/lang/Object;>(Ljava/util/Map<TK;TV;>;)L1java/util/Map<TK;TV;>;
+synchronizedNavigableMap
+ <K:Ljava/lang/Object;V:Ljava/lang/Object;>(Ljava/util/NavigableMap<TK;TV;>;)Ljava/util/NavigableMap<TK;TV;>;
+ <K:Ljava/lang/Object;V:Ljava/lang/Object;>(Ljava/util/NavigableMap<TK;TV;>;)L1java/util/NavigableMap<TK;TV;>;
+synchronizedNavigableSet
+ <T:Ljava/lang/Object;>(Ljava/util/NavigableSet<TT;>;)Ljava/util/NavigableSet<TT;>;
+ <T:Ljava/lang/Object;>(Ljava/util/NavigableSet<TT;>;)L1java/util/NavigableSet<TT;>;
+synchronizedSet
+ <T:Ljava/lang/Object;>(Ljava/util/Set<TT;>;)Ljava/util/Set<TT;>;
+ <T:Ljava/lang/Object;>(Ljava/util/Set<TT;>;)L1java/util/Set<TT;>;
+synchronizedSet
+ <T:Ljava/lang/Object;>(Ljava/util/Set<TT;>;Ljava/lang/Object;)Ljava/util/Set<TT;>;
+ <T:Ljava/lang/Object;>(Ljava/util/Set<TT;>;Ljava/lang/Object;)L1java/util/Set<TT;>;
+synchronizedSortedMap
+ <K:Ljava/lang/Object;V:Ljava/lang/Object;>(Ljava/util/SortedMap<TK;TV;>;)Ljava/util/SortedMap<TK;TV;>;
+ <K:Ljava/lang/Object;V:Ljava/lang/Object;>(Ljava/util/SortedMap<TK;TV;>;)L1java/util/SortedMap<TK;TV;>;
+synchronizedSortedSet
+ <T:Ljava/lang/Object;>(Ljava/util/SortedSet<TT;>;)Ljava/util/SortedSet<TT;>;
+ <T:Ljava/lang/Object;>(Ljava/util/SortedSet<TT;>;)L1java/util/SortedSet<TT;>;
+unmodifiableCollection
+ <T:Ljava/lang/Object;>(Ljava/util/Collection<+TT;>;)Ljava/util/Collection<TT;>;
+ <T:Ljava/lang/Object;>(Ljava/util/Collection<+TT;>;)L1java/util/Collection<TT;>;
+unmodifiableList
+ <T:Ljava/lang/Object;>(Ljava/util/List<+TT;>;)Ljava/util/List<TT;>;
+ <T:Ljava/lang/Object;>(Ljava/util/List<+TT;>;)L1java/util/List<TT;>;
+unmodifiableMap
+ <K:Ljava/lang/Object;V:Ljava/lang/Object;>(Ljava/util/Map<+TK;+TV;>;)Ljava/util/Map<TK;TV;>;
+ <K:Ljava/lang/Object;V:Ljava/lang/Object;>(Ljava/util/Map<+TK;+TV;>;)L1java/util/Map<TK;TV;>;
+unmodifiableNavigableMap
+ <K:Ljava/lang/Object;V:Ljava/lang/Object;>(Ljava/util/NavigableMap<TK;+TV;>;)Ljava/util/NavigableMap<TK;TV;>;
+ <K:Ljava/lang/Object;V:Ljava/lang/Object;>(Ljava/util/NavigableMap<TK;+TV;>;)L1java/util/NavigableMap<TK;TV;>;
+unmodifiableNavigableSet
+ <T:Ljava/lang/Object;>(Ljava/util/NavigableSet<TT;>;)Ljava/util/NavigableSet<TT;>;
+ <T:Ljava/lang/Object;>(Ljava/util/NavigableSet<TT;>;)L1java/util/NavigableSet<TT;>;
+unmodifiableSet
+ <T:Ljava/lang/Object;>(Ljava/util/Set<+TT;>;)Ljava/util/Set<TT;>;
+ <T:Ljava/lang/Object;>(Ljava/util/Set<+TT;>;)L1java/util/Set<TT;>;
+unmodifiableSortedMap
+ <K:Ljava/lang/Object;V:Ljava/lang/Object;>(Ljava/util/SortedMap<TK;+TV;>;)Ljava/util/SortedMap<TK;TV;>;
+ <K:Ljava/lang/Object;V:Ljava/lang/Object;>(Ljava/util/SortedMap<TK;+TV;>;)L1java/util/SortedMap<TK;TV;>;
+unmodifiableSortedSet
+ <T:Ljava/lang/Object;>(Ljava/util/SortedSet<TT;>;)Ljava/util/SortedSet<TT;>;
+ <T:Ljava/lang/Object;>(Ljava/util/SortedSet<TT;>;)L1java/util/SortedSet<TT;>;

--- a/libraries/java/java/util/Iterator.eea
+++ b/libraries/java/java/util/Iterator.eea
@@ -1,0 +1,4 @@
+class java/util/Iterator
+next
+ ()TE;
+ ()T+E;

--- a/libraries/java/java/util/List.eea
+++ b/libraries/java/java/util/List.eea
@@ -1,4 +1,4 @@
 class java/util/List
 get
  (I)TE;
- (I)T1E;
+ (I)T+E;

--- a/libraries/java/java/util/Map$Entry.eea
+++ b/libraries/java/java/util/Map$Entry.eea
@@ -1,0 +1,7 @@
+class java/util/Map$Entry
+getKey
+ ()TK;
+ ()T+K;
+getValue
+ ()TV;
+ ()T+V;

--- a/libraries/java/java/util/Map.eea
+++ b/libraries/java/java/util/Map.eea
@@ -1,4 +1,13 @@
 class java/util/Map
+entrySet
+ ()Ljava/util/Set<Ljava/util/Map$Entry<TK;TV;>;>;
+ ()Ljava/util/Set<L1java/util/Map$Entry<TK;TV;>;>;
 get
  (Ljava/lang/Object;)TV;
+ (Ljava/lang/Object;)T0+V;
+put
+ (TK;TV;)TV;
+ (TK;TV;)T0V;
+remove
  (Ljava/lang/Object;)TV;
+ (Ljava/lang/Object;)T0V;

--- a/libraries/java/java/util/Optional.eea
+++ b/libraries/java/java/util/Optional.eea
@@ -8,3 +8,6 @@ of
 ofNullable
  <T:Ljava/lang/Object;>(TT;)Ljava/util/Optional<TT;>;
  <T:Ljava/lang/Object;>(T0T;)L1java/util/Optional<TT;>;
+orElse
+ (TT;)TT;
+ (T0T;)TT;

--- a/libraries/java/java/util/TreeMap.eea
+++ b/libraries/java/java/util/TreeMap.eea
@@ -1,0 +1,4 @@
+class java/util/TreeMap
+put
+ (TK;TV;)TV;
+ (TK;TV;)T0V;

--- a/libraries/java/java/util/TreeSet.eea
+++ b/libraries/java/java/util/TreeSet.eea
@@ -1,0 +1,4 @@
+class java/util/TreeSet
+pollFirst
+ ()TE;
+ ()T0E;

--- a/libraries/java/java/util/Vector.eea
+++ b/libraries/java/java/util/Vector.eea
@@ -1,0 +1,4 @@
+class java/util/Vector
+get
+ (I)TE;
+ (I)T+E;

--- a/libraries/java/java/util/concurrent/ScheduledExecutorService.eea
+++ b/libraries/java/java/util/concurrent/ScheduledExecutorService.eea
@@ -1,0 +1,4 @@
+class java/util/concurrent/ScheduledExecutorService
+schedule
+ (Ljava/lang/Runnable;JLjava/util/concurrent/TimeUnit;)Ljava/util/concurrent/ScheduledFuture<*>;
+ (Ljava/lang/Runnable;JLjava/util/concurrent/TimeUnit;)L1java/util/concurrent/ScheduledFuture<*>;

--- a/libraries/java/java/util/stream/Collectors.eea
+++ b/libraries/java/java/util/stream/Collectors.eea
@@ -1,0 +1,4 @@
+class java/util/stream/Collectors
+toList
+ <T:Ljava/lang/Object;>()Ljava/util/stream/Collector<TT;*Ljava/util/List<TT;>;>;
+ <T:Ljava/lang/Object;>()Ljava/util/stream/Collector<TT;*L1java/util/List<TT;>;>;


### PR DESCRIPTION
Added annotations.

I changed the annotation of `List.get()`. IMHO your one is not correct. A list can return null if it can store null. The `add` method description states that a NullPointerException is thrown "if the specified element is null and this list does not permit null elements". Why do you think a list cannot return a nullable element?