### PR TITLE
tracecompass' java.* EEAs (2/2)

### DIFF
--- a/libraries/java/java/io/File.eea
+++ b/libraries/java/java/io/File.eea
@@ -2,3 +2,6 @@ class java/io/File
 getAbsolutePath
  ()Ljava/lang/String;
  ()L1java/lang/String;
+getName
+ ()Ljava/lang/String;
+ ()L1java/lang/String;

--- a/libraries/java/java/lang/Class.eea
+++ b/libraries/java/java/lang/Class.eea
@@ -2,3 +2,12 @@ class java/lang/Class
 getAnnotation
  <A::Ljava/lang/annotation/Annotation;>(Ljava/lang/Class<TA;>;)TA;
  <A::Ljava/lang/annotation/Annotation;>(Ljava/lang/Class<TA;>;)T0A;
+getCanonicalName
+ ()Ljava/lang/String;
+ ()L0java/lang/String;
+getName
+ ()Ljava/lang/String;
+ ()L1java/lang/String;
+getSimpleName
+ ()Ljava/lang/String;
+ ()L1java/lang/String;

--- a/libraries/java/java/lang/Integer.eea
+++ b/libraries/java/java/lang/Integer.eea
@@ -1,4 +1,13 @@
 class java/lang/Integer
 toString
+ ()Ljava/lang/String;
+ ()L1java/lang/String;
+toString
  (I)Ljava/lang/String;
  (I)L1java/lang/String;
+toString
+ (II)Ljava/lang/String;
+ (II)L1java/lang/String;
+valueOf
+ (I)Ljava/lang/Integer;
+ (I)L1java/lang/Integer;

--- a/libraries/java/java/util/Arrays.eea
+++ b/libraries/java/java/util/Arrays.eea
@@ -2,3 +2,27 @@ class java/util/Arrays
 asList
  <T:Ljava/lang/Object;>([TT;)Ljava/util/List<TT;>;
  <T:Ljava/lang/Object;>([TT;)L1java/util/List<TT;>;
+stream
+ ([D)Ljava/util/stream/DoubleStream;
+ ([D)L1java/util/stream/DoubleStream;
+stream
+ ([DII)Ljava/util/stream/DoubleStream;
+ ([DII)L1java/util/stream/DoubleStream;
+stream
+ ([I)Ljava/util/stream/IntStream;
+ ([I)L1java/util/stream/IntStream;
+stream
+ ([III)Ljava/util/stream/IntStream;
+ ([III)L1java/util/stream/IntStream;
+stream
+ ([J)Ljava/util/stream/LongStream;
+ ([J)L1java/util/stream/LongStream;
+stream
+ ([JII)Ljava/util/stream/LongStream;
+ ([JII)L1java/util/stream/LongStream;
+stream
+ <T:Ljava/lang/Object;>([TT;)Ljava/util/stream/Stream<TT;>;
+ <T:Ljava/lang/Object;>([TT;)L1java/util/stream/Stream<TT;>;
+stream
+ <T:Ljava/lang/Object;>([TT;II)Ljava/util/stream/Stream<TT;>;
+ <T:Ljava/lang/Object;>([TT;II)L1java/util/stream/Stream<TT;>;

--- a/libraries/java/java/util/Collection.eea
+++ b/libraries/java/java/util/Collection.eea
@@ -5,3 +5,9 @@ parallelStream
 stream
  ()Ljava/util/stream/Stream<TE;>;
  ()Ljava/util/stream/Stream<T+E;>;
+toArray
+ ()[Ljava/lang/Object;
+ ()[1Ljava/lang/Object;
+toArray
+ <T:Ljava/lang/Object;>([TT;)[TT;
+ <T:Ljava/lang/Object;>([1TT;)[1TT;

--- a/libraries/java/java/util/Iterator.eea
+++ b/libraries/java/java/util/Iterator.eea
@@ -1,4 +1,7 @@
 class java/util/Iterator
+forEachRemaining
+ (Ljava/util/function/Consumer<-TE;>;)V
+ (L1java/util/function/Consumer<-TE;>;)V
 next
  ()TE;
  ()T+E;

--- a/libraries/java/java/util/List.eea
+++ b/libraries/java/java/util/List.eea
@@ -2,3 +2,6 @@ class java/util/List
 get
  (I)TE;
  (I)T+E;
+subList
+ (II)Ljava/util/List<TE;>;
+ (II)L1java/util/List<TE;>;

--- a/libraries/java/java/util/Optional.eea
+++ b/libraries/java/java/util/Optional.eea
@@ -2,6 +2,9 @@ class java/util/Optional
 empty
  <T:Ljava/lang/Object;>()Ljava/util/Optional<TT;>;
  <T:Ljava/lang/Object;>()L1java/util/Optional<TT;>;
+get
+ ()TT;
+ ()T1T;
 of
  <T:Ljava/lang/Object;>(TT;)Ljava/util/Optional<TT;>;
  <T:Ljava/lang/Object;>(T1T;)L1java/util/Optional<TT;>;

--- a/libraries/java/java/util/TreeMap.eea
+++ b/libraries/java/java/util/TreeMap.eea
@@ -1,4 +1,7 @@
 class java/util/TreeMap
+get
+ (Ljava/lang/Object;)TV;
+ (Ljava/lang/Object;)T0V;
 put
  (TK;TV;)TV;
  (TK;TV;)T0V;

--- a/libraries/java/java/util/stream/Collectors.eea
+++ b/libraries/java/java/util/stream/Collectors.eea
@@ -1,4 +1,10 @@
 class java/util/stream/Collectors
+toCollection
+ <T:Ljava/lang/Object;C::Ljava/util/Collection<TT;>;>(Ljava/util/function/Supplier<TC;>;)Ljava/util/stream/Collector<TT;*TC;>;
+ <T:Ljava/lang/Object;C::Ljava/util/Collection<TT;>;>(Ljava/util/function/Supplier<TC;>;)Ljava/util/stream/Collector<TT;*T1C;>;
 toList
  <T:Ljava/lang/Object;>()Ljava/util/stream/Collector<TT;*Ljava/util/List<TT;>;>;
  <T:Ljava/lang/Object;>()Ljava/util/stream/Collector<TT;*L1java/util/List<TT;>;>;
+toSet
+ <T:Ljava/lang/Object;>()Ljava/util/stream/Collector<TT;*Ljava/util/Set<TT;>;>;
+ <T:Ljava/lang/Object;>()Ljava/util/stream/Collector<TT;*L1java/util/Set<TT;>;>;


### PR DESCRIPTION
These are the ones I had to indivdually review and in many cases had to manually resolve merges; that's a PITA (and lead me to open ttps://github.com/lastnpe/eclipse-null-eea-augments/issues/16), thus I skipped merged java.lang.String, java.util.Collections and java.util.Map and kept my original ones, and did not merge with tracecompass'

from
https://github.com/tracecompass/tracecompass/tree/master/common/org.eclipse.tracecompass.common.core/annotations/java

for https://github.com/lastnpe/eclipse-null-eea-augments/issues/10