### PR TITLE
add EEAs for java.util.Map

### DIFF
--- a/libraries/java/java/util/Map.eea
+++ b/libraries/java/java/util/Map.eea
@@ -1,13 +1,25 @@
 class java/util/Map
+containsKey
+ (Ljava/lang/Object;)Z
+ (L0java/lang/Object;)Z
+containsValue
+ (Ljava/lang/Object;)Z
+ (L0java/lang/Object;)Z
 entrySet
  ()Ljava/util/Set<Ljava/util/Map$Entry<TK;TV;>;>;
  ()Ljava/util/Set<L1java/util/Map$Entry<TK;TV;>;>;
 get
  (Ljava/lang/Object;)TV;
- (Ljava/lang/Object;)T0+V;
+ (L0java/lang/Object;)T0V;
 put
  (TK;TV;)TV;
  (TK;TV;)T0V;
+putAll
+ (Ljava/util/Map<+TK;+TV;>;)V
+ (L1java/util/Map<+TK;+TV;>;)V
 remove
  (Ljava/lang/Object;)TV;
- (Ljava/lang/Object;)T0V;
+ (L0java/lang/Object;)T0V;
+values
+ ()Ljava/util/Collection<TV;>;
+ ()L1java/util/Collection<T+V;>;


### PR DESCRIPTION
* `containsKey` allows `null` argument
* `containsValue` allows `null` argument
* `get` AFAIK the notation `T0+V` doesn't make sense.
   IMHO There are this options for generic type (e.g. V):
   * `T0V`: nullable
   * `T1V`: non-null
   * `T+V`: null annotation is derived by the generic type
* `putAll` needs a non-null argument
* `remove` can return null
* `values` wil lreturn a non-null collection that members are nullable
   or non dependent on the generic type one
