### PR TITLE
add EEAs for java.util.concurrent.Executors

### DIFF
--- a/libraries/java/java/util/concurrent/Executors.eea
+++ b/libraries/java/java/util/concurrent/Executors.eea
@@ -1,0 +1,4 @@
+class java/util/concurrent/Executors
+newSingleThreadExecutor
+ (Ljava/util/concurrent/ThreadFactory;)Ljava/util/concurrent/ExecutorService;
+ (Ljava/util/concurrent/ThreadFactory;)L1java/util/concurrent/ExecutorService;


### PR DESCRIPTION
* `newSingleThreadExecutor` returns a non-null reference