### PR TITLE
Bump org.eclipse.jdt.annotation from 2.0.0 to 2.1.0

### DIFF
--- a/examples/maven/parent/pom.xml
+++ b/examples/maven/parent/pom.xml
@@ -121,7 +121,7 @@
     <dependency>
       <groupId>org.eclipse.jdt</groupId>
       <artifactId>org.eclipse.jdt.annotation</artifactId>
-      <version>2.0.0</version>
+      <version>2.1.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
see https://bugs.eclipse.org/bugs/show_bug.cgi?id=489900

This lets us use the org.eclipse.jdt.annotation.Checks utility,
announced on https://www.eclipse.org/eclipse/news/4.6/M6.