### PR TITLE
String.equalsIgnoreCase accepts null

### DIFF
--- a/libraries/java/java/lang/String.eea
+++ b/libraries/java/java/lang/String.eea
@@ -31,7 +31,7 @@ equals
  (L0java/lang/Object;)Z
 equalsIgnoreCase
  (Ljava/lang/String;)Z
- (L1java/lang/String;)Z
+ (L0java/lang/String;)Z
 format
  (Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;
  (L1java/lang/String;[Ljava/lang/Object;)L1java/lang/String;
@@ -98,6 +98,15 @@ startsWith
 startsWith
  (Ljava/lang/String;I)Z
  (L1java/lang/String;I)Z
+subSequence
+ (II)Ljava/lang/CharSequence;
+ (II)L1java/lang/CharSequence;
+substring
+ (I)Ljava/lang/String;
+ (I)L1java/lang/String;
+substring
+ (II)Ljava/lang/String;
+ (II)L1java/lang/String;
 toCharArray
  ()[C
  ()[1C


### PR DESCRIPTION
After merging the recent updates in the String EEA, this is the only
issue I noticed locally.

Signed-off-by: Michael Keppler <michael.keppler@gmx.de>