### PR TITLE
FIX: corrections for guava 25.1

### DIFF
--- a/libraries/guava/com/google/common/base/Objects$ToStringHelper.eea
+++ b/libraries/guava/com/google/common/base/Objects$ToStringHelper.eea
@@ -1,4 +1,0 @@
-class com/google/common/base/Objects$ToStringHelper
-toString
- ()Ljava/lang/String;
- ()L1java/lang/String;

--- a/libraries/guava/com/google/common/collect/HashBiMap.eea
+++ b/libraries/guava/com/google/common/collect/HashBiMap.eea
@@ -3,8 +3,8 @@ create
  <K:Ljava/lang/Object;V:Ljava/lang/Object;>()Lcom/google/common/collect/HashBiMap<TK;TV;>;
  <K:Ljava/lang/Object;V:Ljava/lang/Object;>()L1com/google/common/collect/HashBiMap<TK;TV;>;
 create
- <K:Ljava/lang/Object;V:Ljava/lang/Object;>(II)Lcom/google/common/collect/HashBiMap<TK;TV;>;
- <K:Ljava/lang/Object;V:Ljava/lang/Object;>(II)L1com/google/common/collect/HashBiMap<TK;TV;>;
+ <K:Ljava/lang/Object;V:Ljava/lang/Object;>(I)Lcom/google/common/collect/HashBiMap<TK;TV;>;
+ <K:Ljava/lang/Object;V:Ljava/lang/Object;>(I)L1com/google/common/collect/HashBiMap<TK;TV;>;
 create
  <K:Ljava/lang/Object;V:Ljava/lang/Object;>(Ljava/util/Map<+TK;+TV;>;)Lcom/google/common/collect/HashBiMap<TK;TV;>;
  <K:Ljava/lang/Object;V:Ljava/lang/Object;>(Ljava/util/Map<+TK;+TV;>;)L1com/google/common/collect/HashBiMap<TK;TV;>;

--- a/libraries/guava/com/google/common/collect/ImmutableList.eea
+++ b/libraries/guava/com/google/common/collect/ImmutableList.eea
@@ -1,7 +1,4 @@
 class com/google/common/collect/ImmutableList
-EMPTY
- Lcom/google/common/collect/ImmutableList<Ljava/lang/Object;>;
- L1com/google/common/collect/ImmutableList<Ljava/lang/Object;>;
 builder
  <E:Ljava/lang/Object;>()Lcom/google/common/collect/ImmutableList$Builder<TE;>;
  <E:Ljava/lang/Object;>()L1com/google/common/collect/ImmutableList$Builder<TE;>;

--- a/libraries/guava/com/google/common/util/concurrent/Futures.eea
+++ b/libraries/guava/com/google/common/util/concurrent/Futures.eea
@@ -17,9 +17,6 @@ catchingAsync
 catchingAsync
  <V:Ljava/lang/Object;X:Ljava/lang/Throwable;>(Lcom/google/common/util/concurrent/ListenableFuture<+TV;>;Ljava/lang/Class<TX;>;Lcom/google/common/util/concurrent/AsyncFunction<-TX;+TV;>;Ljava/util/concurrent/Executor;)Lcom/google/common/util/concurrent/ListenableFuture<TV;>;
  <V:Ljava/lang/Object;X:Ljava/lang/Throwable;>(Lcom/google/common/util/concurrent/ListenableFuture<+TV;>;Ljava/lang/Class<TX;>;Lcom/google/common/util/concurrent/AsyncFunction<-TX;+TV;>;Ljava/util/concurrent/Executor;)L1com/google/common/util/concurrent/ListenableFuture<TV;>;
-dereference
- <V:Ljava/lang/Object;>(Lcom/google/common/util/concurrent/ListenableFuture<+Lcom/google/common/util/concurrent/ListenableFuture<+TV;>;>;)Lcom/google/common/util/concurrent/ListenableFuture<TV;>;
- <V:Ljava/lang/Object;>(Lcom/google/common/util/concurrent/ListenableFuture<+Lcom/google/common/util/concurrent/ListenableFuture<+TV;>;>;)L1com/google/common/util/concurrent/ListenableFuture<TV;>;
 getChecked
  <V:Ljava/lang/Object;X:Ljava/lang/Exception;>(Ljava/util/concurrent/Future<TV;>;Ljava/lang/Class<TX;>;)TV;^TX;
  <V:Ljava/lang/Object;X:Ljava/lang/Exception;>(Ljava/util/concurrent/Future<TV;>;Ljava/lang/Class<TX;>;)T1V;


### PR DESCRIPTION
detected by #72 

I tried to run the test against guava-19 and -25.1 
Unfortunately, version 25 reports that Objects$ToStringHelper is missing (which was there in v19), but v19 reports a lot of other errors of missing functions, that came later.

So, for #72 to pass, we need an exact guava version to test against. Do you think it would be OK to test against the latest and remove .eea definitions of older ones?
