### PR TITLE
fix String.contentEquals(CharSequence)

### DIFF
--- a/libraries/java/java/lang/String.eea
+++ b/libraries/java/java/lang/String.eea
@@ -13,7 +13,7 @@ contains
  (L1java/lang/CharSequence;)Z
 contentEquals
  (Ljava/lang/CharSequence;)Z
- (L0java/lang/CharSequence;)Z
+ (L1java/lang/CharSequence;)Z
 contentEquals
  (Ljava/lang/StringBuffer;)Z
  (L1java/lang/StringBuffer;)Z


### PR DESCRIPTION
That is implemented as a series of instanceof checks and a dereference
afterwards. Null arguments will therefore lead to runtime failure, even
though there is no explicit non null requirement.