### PR TITLE
Add servlet-api, xstream EEAs and fix missing javamail from eea-all

### DIFF
--- a/libraries/eea-all/pom.xml
+++ b/libraries/eea-all/pom.xml
@@ -16,6 +16,11 @@
   <dependencies>
     <dependency>
       <groupId>org.lastnpe.eea</groupId>
+      <artifactId>javamail-eea</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.lastnpe.eea</groupId>
       <artifactId>jdk-eea</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -31,6 +36,11 @@
     </dependency>
     <dependency>
       <groupId>org.lastnpe.eea</groupId>
+      <artifactId>servlet-api-eea</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.lastnpe.eea</groupId>
       <artifactId>slf4j-api-eea</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -42,6 +52,11 @@
     <dependency>
       <groupId>org.lastnpe.eea</groupId>
       <artifactId>osgi-core-eea</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.lastnpe.eea</groupId>
+      <artifactId>xstream-eea</artifactId>
       <version>${project.version}</version>
     </dependency>
 
@@ -63,6 +78,27 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>25.1-jre</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.sun.mail</groupId>
+      <artifactId>javax.mail</artifactId>
+      <version>1.6.2</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.thoughtworks.xstream</groupId>
+      <artifactId>xstream</artifactId>
+      <version>1.4.13</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.1.0</version>
       <scope>test</scope>
     </dependency>
 

--- a/libraries/java/javax/security/auth/callback/CallbackHandler.eea
+++ b/libraries/java/javax/security/auth/callback/CallbackHandler.eea
@@ -1,0 +1,4 @@
+class javax/security/auth/callback/CallbackHandler
+handle
+ ([Ljavax/security/auth/callback/Callback;)V
+ ([L1javax/security/auth/callback/Callback;)V

--- a/libraries/pom.xml
+++ b/libraries/pom.xml
@@ -45,13 +45,15 @@
 
   <modules>
     <module>eea-all</module>
-    <module>java</module>
-    <module>slf4j-api</module>
-    <module>mockito</module>
     <module>guava</module>
-    <module>spring</module>
-    <module>osgi-core</module>
+    <module>java</module>
     <module>javamail</module>
+    <module>mockito</module>
+    <module>osgi-core</module>
+    <module>slf4j-api</module>
+    <module>servlet-api</module>
+    <module>spring</module>
+    <module>xstream</module>
   </modules>
 
   <scm>

--- a/libraries/servlet-api/eea-for-gav
+++ b/libraries/servlet-api/eea-for-gav
@@ -1,0 +1,1 @@
+javax.servlet:javax.servlet-api

--- a/libraries/servlet-api/javax/servlet/Servlet.eea
+++ b/libraries/servlet-api/javax/servlet/Servlet.eea
@@ -1,0 +1,13 @@
+class javax/servlet/Servlet
+getServletConfig
+ ()Ljavax/servlet/ServletConfig;
+ ()L0javax/servlet/ServletConfig;
+getServletInfo
+ ()Ljava/lang/String;
+ ()L0java/lang/String;
+init
+ (Ljavax/servlet/ServletConfig;)V
+ (L0javax/servlet/ServletConfig;)V
+service
+ (Ljavax/servlet/ServletRequest;Ljavax/servlet/ServletResponse;)V
+ (L1javax/servlet/ServletRequest;L1javax/servlet/ServletResponse;)V

--- a/libraries/servlet-api/javax/servlet/ServletRequest.eea
+++ b/libraries/servlet-api/javax/servlet/ServletRequest.eea
@@ -1,4 +1,7 @@
 class javax/servlet/ServletRequest
+getCharacterEncoding
+ ()Ljava/lang/String;
+ ()L0java/lang/String;
 getContentType
  ()Ljava/lang/String;
  ()L0java/lang/String;
@@ -16,7 +19,7 @@ getParameterNames
  ()L1java/util/Enumeration<Ljava/lang/String;>;
 getParameterValues
  (Ljava/lang/String;)[Ljava/lang/String;
- (L1java/lang/String;)[L0java/lang/String;
+ (L1java/lang/String;)[0L1java/lang/String;
 setCharacterEncoding
  (Ljava/lang/String;)V
- (L1java/lang/String;)V
+ (L0java/lang/String;)V

--- a/libraries/servlet-api/javax/servlet/ServletRequest.eea
+++ b/libraries/servlet-api/javax/servlet/ServletRequest.eea
@@ -1,0 +1,22 @@
+class javax/servlet/ServletRequest
+getContentType
+ ()Ljava/lang/String;
+ ()L0java/lang/String;
+getInputStream
+ ()Ljavax/servlet/ServletInputStream;
+ ()L1javax/servlet/ServletInputStream;
+getParameter
+ (Ljava/lang/String;)Ljava/lang/String;
+ (L1java/lang/String;)L0java/lang/String;
+getParameterMap
+ ()Ljava/util/Map<Ljava/lang/String;[Ljava/lang/String;>;
+ ()L1java/util/Map<Ljava/lang/String;[Ljava/lang/String;>;
+getParameterNames
+ ()Ljava/util/Enumeration<Ljava/lang/String;>;
+ ()L1java/util/Enumeration<Ljava/lang/String;>;
+getParameterValues
+ (Ljava/lang/String;)[Ljava/lang/String;
+ (L1java/lang/String;)[L0java/lang/String;
+setCharacterEncoding
+ (Ljava/lang/String;)V
+ (L1java/lang/String;)V

--- a/libraries/servlet-api/javax/servlet/ServletResponse.eea
+++ b/libraries/servlet-api/javax/servlet/ServletResponse.eea
@@ -1,7 +1,7 @@
 class javax/servlet/ServletResponse
 getCharacterEncoding
  ()Ljava/lang/String;
- ()L1java/lang/String;
+ ()L0java/lang/String;
 getContentType
  ()Ljava/lang/String;
  ()L0java/lang/String;

--- a/libraries/servlet-api/javax/servlet/ServletResponse.eea
+++ b/libraries/servlet-api/javax/servlet/ServletResponse.eea
@@ -1,0 +1,25 @@
+class javax/servlet/ServletResponse
+getCharacterEncoding
+ ()Ljava/lang/String;
+ ()L1java/lang/String;
+getContentType
+ ()Ljava/lang/String;
+ ()L0java/lang/String;
+getLocale
+ ()Ljava/util/Locale;
+ ()L1java/util/Locale;
+getOutputStream
+ ()Ljavax/servlet/ServletOutputStream;
+ ()L1javax/servlet/ServletOutputStream;
+getWriter
+ ()Ljava/io/PrintWriter;
+ ()L1java/io/PrintWriter;
+setCharacterEncoding
+ (Ljava/lang/String;)V
+ (L0java/lang/String;)V
+setContentType
+ (Ljava/lang/String;)V
+ (L0java/lang/String;)V
+setLocale
+ (Ljava/util/Locale;)V
+ (L0java/util/Locale;)V

--- a/libraries/servlet-api/javax/servlet/http/HttpServlet.eea
+++ b/libraries/servlet-api/javax/servlet/http/HttpServlet.eea
@@ -1,0 +1,34 @@
+class javax/servlet/http/HttpServlet
+doDelete
+ (Ljavax/servlet/http/HttpServletRequest;Ljavax/servlet/http/HttpServletResponse;)V
+ (L1javax/servlet/http/HttpServletRequest;L1javax/servlet/http/HttpServletResponse;)V
+doGet
+ (Ljavax/servlet/http/HttpServletRequest;Ljavax/servlet/http/HttpServletResponse;)V
+ (L1javax/servlet/http/HttpServletRequest;L1javax/servlet/http/HttpServletResponse;)V
+doHead
+ (Ljavax/servlet/http/HttpServletRequest;Ljavax/servlet/http/HttpServletResponse;)V
+ (L1javax/servlet/http/HttpServletRequest;L1javax/servlet/http/HttpServletResponse;)V
+doOptions
+ (Ljavax/servlet/http/HttpServletRequest;Ljavax/servlet/http/HttpServletResponse;)V
+ (L1javax/servlet/http/HttpServletRequest;L1javax/servlet/http/HttpServletResponse;)V
+doPost
+ (Ljavax/servlet/http/HttpServletRequest;Ljavax/servlet/http/HttpServletResponse;)V
+ (L1javax/servlet/http/HttpServletRequest;L1javax/servlet/http/HttpServletResponse;)V
+doPut
+ (Ljavax/servlet/http/HttpServletRequest;Ljavax/servlet/http/HttpServletResponse;)V
+ (L1javax/servlet/http/HttpServletRequest;L1javax/servlet/http/HttpServletResponse;)V
+doTrace
+ (Ljavax/servlet/http/HttpServletRequest;Ljavax/servlet/http/HttpServletResponse;)V
+ (L1javax/servlet/http/HttpServletRequest;L1javax/servlet/http/HttpServletResponse;)V
+getLastModified
+ (Ljavax/servlet/http/HttpServletRequest;)J
+ (L1javax/servlet/http/HttpServletRequest;)J
+maybeSetLastModified
+ (Ljavax/servlet/http/HttpServletResponse;J)V
+ (L1javax/servlet/http/HttpServletResponse;J)V
+service
+ (Ljavax/servlet/ServletRequest;Ljavax/servlet/ServletResponse;)V
+ (L1javax/servlet/ServletRequest;L1javax/servlet/ServletResponse;)V
+service
+ (Ljavax/servlet/http/HttpServletRequest;Ljavax/servlet/http/HttpServletResponse;)V
+ (L1javax/servlet/http/HttpServletRequest;L1javax/servlet/http/HttpServletResponse;)V

--- a/libraries/servlet-api/javax/servlet/http/HttpServletRequest.eea
+++ b/libraries/servlet-api/javax/servlet/http/HttpServletRequest.eea
@@ -1,0 +1,94 @@
+class javax/servlet/http/HttpServletRequest
+BASIC_AUTH
+ Ljava/lang/String;
+ L1java/lang/String;
+CLIENT_CERT_AUTH
+ Ljava/lang/String;
+ L1java/lang/String;
+DIGEST_AUTH
+ Ljava/lang/String;
+ L1java/lang/String;
+FORM_AUTH
+ Ljava/lang/String;
+ L1java/lang/String;
+authenticate
+ (Ljavax/servlet/http/HttpServletResponse;)Z
+ (L1javax/servlet/http/HttpServletResponse;)Z
+changeSessionId
+ ()Ljava/lang/String;
+ ()L1java/lang/String;
+getAuthType
+ ()Ljava/lang/String;
+ ()L0java/lang/String;
+getContextPath
+ ()Ljava/lang/String;
+ ()L0java/lang/String;
+getCookies
+ ()[Ljavax/servlet/http/Cookie;
+ ()[L0javax/servlet/http/Cookie;
+getDateHeader
+ (Ljava/lang/String;)J
+ (L1java/lang/String;)J
+getHeader
+ (Ljava/lang/String;)Ljava/lang/String;
+ (L1java/lang/String;)L0java/lang/String;
+getHeaderNames
+ ()Ljava/util/Enumeration<Ljava/lang/String;>;
+ ()L0java/util/Enumeration<Ljava/lang/String;>;
+getHeaders
+ (Ljava/lang/String;)Ljava/util/Enumeration<Ljava/lang/String;>;
+ (L1java/lang/String;)L0java/util/Enumeration<Ljava/lang/String;>;
+getIntHeader
+ (Ljava/lang/String;)I
+ (L1java/lang/String;)I
+getMethod
+ ()Ljava/lang/String;
+ ()L0java/lang/String;
+getPart
+ (Ljava/lang/String;)Ljavax/servlet/http/Part;
+ (L1java/lang/String;)L0javax/servlet/http/Part;
+getParts
+ ()Ljava/util/Collection<Ljavax/servlet/http/Part;>;
+ ()L1java/util/Collection<Ljavax/servlet/http/Part;>;
+getPathInfo
+ ()Ljava/lang/String;
+ ()L0java/lang/String;
+getPathTranslated
+ ()Ljava/lang/String;
+ ()L0java/lang/String;
+getQueryString
+ ()Ljava/lang/String;
+ ()L0java/lang/String;
+getRemoteUser
+ ()Ljava/lang/String;
+ ()L0java/lang/String;
+getRequestURI
+ ()Ljava/lang/String;
+ ()L0java/lang/String;
+getRequestURL
+ ()Ljava/lang/StringBuffer;
+ ()L0java/lang/StringBuffer;
+getRequestedSessionId
+ ()Ljava/lang/String;
+ ()L0java/lang/String;
+getServletPath
+ ()Ljava/lang/String;
+ ()L1java/lang/String;
+getSession
+ ()Ljavax/servlet/http/HttpSession;
+ ()L1javax/servlet/http/HttpSession;
+getSession
+ (Z)Ljavax/servlet/http/HttpSession;
+ (Z)L0javax/servlet/http/HttpSession;
+getUserPrincipal
+ ()Ljava/security/Principal;
+ ()L0java/security/Principal;
+isUserInRole
+ (Ljava/lang/String;)Z
+ (L1java/lang/String;)Z
+login
+ (Ljava/lang/String;Ljava/lang/String;)V
+ (L1java/lang/String;L1java/lang/String;)V
+upgrade
+ <T::Ljavax/servlet/http/HttpUpgradeHandler;>(Ljava/lang/Class<TT;>;)TT;
+ <T::Ljavax/servlet/http/HttpUpgradeHandler;>(L1java/lang/Class<TT;>;)T1T;

--- a/libraries/servlet-api/javax/servlet/http/HttpServletRequest.eea
+++ b/libraries/servlet-api/javax/servlet/http/HttpServletRequest.eea
@@ -25,7 +25,7 @@ getContextPath
  ()L0java/lang/String;
 getCookies
  ()[Ljavax/servlet/http/Cookie;
- ()[L0javax/servlet/http/Cookie;
+ ()[0L1javax/servlet/http/Cookie;
 getDateHeader
  (Ljava/lang/String;)J
  (L1java/lang/String;)J

--- a/libraries/servlet-api/javax/servlet/http/HttpServletResponse.eea
+++ b/libraries/servlet-api/javax/servlet/http/HttpServletResponse.eea
@@ -1,0 +1,55 @@
+class javax/servlet/http/HttpServletResponse
+addCookie
+ (Ljavax/servlet/http/Cookie;)V
+ (L1javax/servlet/http/Cookie;)V
+addDateHeader
+ (Ljava/lang/String;J)V
+ (L1java/lang/String;J)V
+addHeader
+ (Ljava/lang/String;Ljava/lang/String;)V
+ (L1java/lang/String;L0java/lang/String;)V
+addIntHeader
+ (Ljava/lang/String;I)V
+ (L1java/lang/String;I)V
+containsHeader
+ (Ljava/lang/String;)Z
+ (L1java/lang/String;)Z
+encodeRedirectURL
+ (Ljava/lang/String;)Ljava/lang/String;
+ (L0java/lang/String;)L0java/lang/String;
+encodeRedirectUrl
+ (Ljava/lang/String;)Ljava/lang/String;
+ (L0java/lang/String;)L0java/lang/String;
+encodeURL
+ (Ljava/lang/String;)Ljava/lang/String;
+ (L0java/lang/String;)L0java/lang/String;
+encodeUrl
+ (Ljava/lang/String;)Ljava/lang/String;
+ (L0java/lang/String;)L0java/lang/String;
+getHeader
+ (Ljava/lang/String;)Ljava/lang/String;
+ (L1java/lang/String;)L0java/lang/String;
+getHeaders
+ (Ljava/lang/String;)Ljava/util/Collection<Ljava/lang/String;>;
+ (L1java/lang/String;)L1java/util/Collection<Ljava/lang/String;>;
+getHeaderNames
+ ()Ljava/util/Collection<Ljava/lang/String;>;
+ ()L1java/util/Collection<Ljava/lang/String;>;
+sendError
+ (ILjava/lang/String;)V
+ (IL0java/lang/String;)V
+sendRedirect
+ (Ljava/lang/String;)V
+ (L1java/lang/String;)V
+setDateHeader
+ (Ljava/lang/String;J)V
+ (L1java/lang/String;J)V
+setHeader
+ (Ljava/lang/String;Ljava/lang/String;)V
+ (L1java/lang/String;L0java/lang/String;)V
+setIntHeader
+ (Ljava/lang/String;I)V
+ (L1java/lang/String;I)V
+setStatus
+ (ILjava/lang/String;)V
+ (IL0java/lang/String;)V

--- a/libraries/servlet-api/pom.xml
+++ b/libraries/servlet-api/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <!-- TODO This file should be auto-generated from a template, based on directory, not hand-maintained -->
+
+  <parent>
+    <groupId>org.lastnpe.eea</groupId>
+    <artifactId>eea-parent</artifactId>
+    <version>2.2.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>servlet-api-eea</artifactId>
+  <name>EEA :: servlet-api</name>
+
+  <!-- Do NOT use a <version> of the JAR for which this is an EEA here,
+       but version the EEA itself.  Put the version of the lib into
+       the EEA's name, if at all.-->
+
+</project>

--- a/libraries/xstream/com/thoughtworks/xstream/XStream.eea
+++ b/libraries/xstream/com/thoughtworks/xstream/XStream.eea
@@ -1,0 +1,13 @@
+class com/thoughtworks/xstream/XStream
+alias
+ (Ljava/lang/String;Ljava/lang/Class;)V
+ (L1java/lang/String;L1java/lang/Class;)V
+allowTypesByWildcard
+ ([Ljava/lang/String;)V
+ ([L0java/lang/String;)V
+registerConverter
+ (Lcom/thoughtworks/xstream/converters/Converter;)V
+ (L1com/thoughtworks/xstream/converters/Converter;)V
+setupDefaultSecurity
+ (Lcom/thoughtworks/xstream/XStream;)V
+ (L1com/thoughtworks/xstream/XStream;)V

--- a/libraries/xstream/com/thoughtworks/xstream/XStream.eea
+++ b/libraries/xstream/com/thoughtworks/xstream/XStream.eea
@@ -4,7 +4,7 @@ alias
  (L1java/lang/String;L1java/lang/Class;)V
 allowTypesByWildcard
  ([Ljava/lang/String;)V
- ([L0java/lang/String;)V
+ ([0Ljava/lang/String;)V
 registerConverter
  (Lcom/thoughtworks/xstream/converters/Converter;)V
  (L1com/thoughtworks/xstream/converters/Converter;)V

--- a/libraries/xstream/com/thoughtworks/xstream/converters/ConversionException.eea
+++ b/libraries/xstream/com/thoughtworks/xstream/converters/ConversionException.eea
@@ -1,0 +1,10 @@
+class com/thoughtworks/xstream/converters/ConversionException
+<init>
+ (Ljava/lang/String;)V
+ (L0java/lang/String;)V
+<init>
+ (Ljava/lang/String;Ljava/lang/Throwable;)V
+ (L0java/lang/String;L0java/lang/Throwable;)V
+<init>
+ (Ljava/lang/Throwable;)V
+ (L0java/lang/Throwable;)V

--- a/libraries/xstream/com/thoughtworks/xstream/converters/Converter.eea
+++ b/libraries/xstream/com/thoughtworks/xstream/converters/Converter.eea
@@ -1,0 +1,7 @@
+class com/thoughtworks/xstream/converters/Converter
+marshal
+ (Ljava/lang/Object;Lcom/thoughtworks/xstream/io/HierarchicalStreamWriter;Lcom/thoughtworks/xstream/converters/MarshallingContext;)V
+ (L0java/lang/Object;L1com/thoughtworks/xstream/io/HierarchicalStreamWriter;L1com/thoughtworks/xstream/converters/MarshallingContext;)V
+unmarshal
+ (Lcom/thoughtworks/xstream/io/HierarchicalStreamReader;Lcom/thoughtworks/xstream/converters/UnmarshallingContext;)Ljava/lang/Object;
+ (L1com/thoughtworks/xstream/io/HierarchicalStreamReader;L1com/thoughtworks/xstream/converters/UnmarshallingContext;)L0java/lang/Object;

--- a/libraries/xstream/eea-for-gav
+++ b/libraries/xstream/eea-for-gav
@@ -1,0 +1,1 @@
+com.thoughtworks.xstream:xstream

--- a/libraries/xstream/pom.xml
+++ b/libraries/xstream/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <!-- TODO This file should be auto-generated from a template, based on directory, not hand-maintained -->
+
+  <parent>
+    <groupId>org.lastnpe.eea</groupId>
+    <artifactId>eea-parent</artifactId>
+    <version>2.2.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>xstream-eea</artifactId>
+  <name>EEA :: xstream</name>
+
+  <!-- Do NOT use a <version> of the JAR for which this is an EEA here,
+       but version the EEA itself.  Put the version of the lib into
+       the EEA's name, if at all.-->
+
+</project>


### PR DESCRIPTION
Adds EEAs for:

* javax.security.auth.callback.CallbackHandler
* javax.servlet.Servlet
* javax.servlet.ServletRequest
* javax.servlet.ServletResponse
* javax.servlet.http.HttpServlet
* javax.servlet.http.HttpServletRequest
* javax.servlet.http.HttpServletResponse
* com.thoughtworks.xstream.XStream
* com.thoughtworks.xstream.converters.ConversionException
* com.thoughtworks.xstream.converters.Converter

Also fixes the javamail EEAs missing from eea-all.