### PR TITLE
remove parent-pom from libraries-pom

### DIFF
--- a/examples/maven/pom.xml
+++ b/examples/maven/pom.xml
@@ -21,6 +21,11 @@
     <module>hello</module>
   </modules>
 
+  <properties>
+    <eea.java.version>11</eea.java.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
   <dependencies>
     <!-- The dual use of org.eclipse.jdt.annotation.Nullable
          as well as javax.annotation.Nullable from FindBugs

--- a/libraries/pom.xml
+++ b/libraries/pom.xml
@@ -2,13 +2,10 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>org.lastnpe.eea</groupId>
-    <artifactId>eea-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
-  </parent>
-
+  <groupId>org.lastnpe.eea</groupId>
   <artifactId>eea-parent</artifactId>
+  <version>2.2.0-SNAPSHOT</version>
+
   <packaging>pom</packaging>
 
   <name>EEA :: Reactor</name>
@@ -70,6 +67,11 @@
     <!-- <repository> isn't needed with nexus-staging-maven-plugin, it somehow
          has this hard-coded or automatically find sit somehow, IFF <version> is non-SNAPSHOT -->
   </distributionManagement>
+
+  <properties>
+    <eea.java.version>11</eea.java.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
 
   <build>
     <!-- NB: Similar configuration also in examples/maven/jdt-ecj-settings/pom.xml -->

--- a/pom.xml
+++ b/pom.xml
@@ -15,9 +15,4 @@
     <module>examples/maven</module>
   </modules>
 
-  <properties>
-    <eea.java.version>11</eea.java.version>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  </properties>
-
 </project>


### PR DESCRIPTION
The previously added parent-section in the base-pom for the libraries required the root pom to be released. This is unnecessary and prevented by this change

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>