### PR TITLE
fix map

### DIFF
--- a/libraries/java/java/util/Map.eea
+++ b/libraries/java/java/util/Map.eea
@@ -4,10 +4,10 @@ compute
  (TK;L1java/util/function/BiFunction<-TK;-TV;+TV;>;)T0V;
 computeIfAbsent
  (TK;Ljava/util/function/Function<-TK;+TV;>;)TV;
- (TK;L1java/util/function/Function<-TK;+TV;>;)T0V;
+ (TK;L1java/util/function/Function<-TK;+T0V;>;)T0V;
 computeIfPresent
  (TK;Ljava/util/function/BiFunction<-TK;-TV;+TV;>;)TV;
- (TK;L1java/util/function/BiFunction<-TK;-TV;+TV;>;)T0V;
+ (TK;L1java/util/function/BiFunction<-TK;-TV;+T0V;>;)T0V;
 containsKey
  (Ljava/lang/Object;)Z
  (L0java/lang/Object;)Z


### PR DESCRIPTION
the supplier functions are allowed to return null, in that case the mapping is removed

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>