### PR TITLE
fix map compute

### DIFF
--- a/libraries/java/java/util/Map.eea
+++ b/libraries/java/java/util/Map.eea
@@ -1,7 +1,7 @@
 class java/util/Map
 compute
  (TK;Ljava/util/function/BiFunction<-TK;-TV;+TV;>;)TV;
- (TK;L1java/util/function/BiFunction<-TK;-TV;+T0V;>;)T0V;
+ (TK;L1java/util/function/BiFunction<-TK;-T0V;+T0V;>;)T0V;
 computeIfAbsent
  (TK;Ljava/util/function/Function<-TK;+TV;>;)TV;
  (TK;L1java/util/function/Function<-TK;+T0V;>;)T0V;


### PR DESCRIPTION
The value that is passed to the mapping function might be null (if the key does not exist).

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>