### PR TITLE
ci: improve github workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,19 +70,25 @@ jobs:
 
 
     - name: "Install: JDK 17 ☕"
+      id: setup-java-17
       uses: actions/setup-java@v4  # https://github.com/actions/setup-java
       with:
         distribution: temurin
         java-version: 17
-    - run: echo "JAVA17_HOME=$JAVA_HOME" >> $GITHUB_ENV
 
 
     - name: "Install: JDK 21 ☕"
+      id: setup-java-21
       uses: actions/setup-java@v4  # https://github.com/actions/setup-java
       with:
         distribution: temurin
         java-version: 21
-    - run: echo "JAVA21_HOME=$JAVA_HOME" >> $GITHUB_ENV
+
+
+    - name: Set JAVA_HOME env vars
+      run: |
+        echo "JAVA17_HOME=${{ steps.setup-java-17.outputs.path }}" >> $GITHUB_ENV
+        echo "JAVA21_HOME=${{ steps.setup-java-21.outputs.path }}" >> $GITHUB_ENV
 
 
     - name: "Show: toolchains.xml"
@@ -91,13 +97,13 @@ jobs:
 
     - name: "Cache: Local Maven Repository"
       uses: actions/cache@v4
-      if: ${{ !env.ACT }}  # https://github.com/nektos/act#skipping-steps
       with:
         # Excluded sub directory not working https://github.com/actions/toolkit/issues/713
         path: |
           ~/.m2/repository/*
           !~/.m2/repository/*SNAPSHOT*
         key: ${{ runner.os }}-mvn-${{ hashFiles('**/pom.xml') }}
+
 
     - name: Prepare Maven Snapshots Repo
       if: ${{ github.ref_name == 'main' && !env.ACT }}  # https://github.com/nektos/act#skipping-steps
@@ -150,7 +156,7 @@ jobs:
 
         ./mvnw \
           --errors \
-          --update-snapshots \
+          --no-transfer-progress \
           --batch-mode \
           --show-version \
           ${{ github.event.inputs.additional_maven_args }} \


### PR DESCRIPTION
This commit:
1. disables excessive Maven transfer logging to the console,
2. enables caching when running workflows with nektos/act, and
3. implements a more reliable way to populate JAVA17_HOME and JAVA21_HOME