### PR TITLE
feat: add library input to update-eea-files workflow

### DIFF
--- a/.github/workflows/update-eea-files.yml
+++ b/.github/workflows/update-eea-files.yml
@@ -16,6 +16,10 @@ on:
         description: 'Additional Maven Args'
         required: false
         default: ''
+      library:
+        description: 'Name of the library to update (e.g. java-17). If left empty all libraries are updated.'
+        required: false
+        default: ''
 
 
 defaults:
@@ -73,6 +77,7 @@ jobs:
 
     - name: "Cache: Local Maven Repository"
       uses: actions/cache@v4
+      if: ${{ !github.event.inputs.additional_maven_args && !github.event.inputs.library }}
       with:
         # Excluded sub directory not working https://github.com/actions/toolkit/issues/713
         path: |
@@ -98,9 +103,10 @@ jobs:
           --no-transfer-progress \
           --batch-mode \
           --show-version \
-          ${{ github.event.inputs.additional_maven_args }} \
           clean verify \
-          -Deea-generator.action=generate
+          $( [[ -n "${{ github.event.inputs.library }}"  ]] && echo '-pl "libraries/${{ github.event.inputs.library }}" -am' || true ) \
+          -Deea-generator.action=generate \
+          ${{ github.event.inputs.additional_maven_args }}
 
         updates=$(git -C . ls-files -o -m -d --exclude-standard | head -n 50 || true)  # "|| true" is to mitgate exit code 141
 
@@ -118,14 +124,14 @@ jobs:
     - name: Create PR
       id: create-pr
       uses: peter-evans/create-pull-request@v6  # https://github.com/peter-evans/create-pull-request
-      if: "${{ steps.eea_updates.outputs.updates != '' }}"
+      if: steps.eea_updates.outputs.updates
       with:
-        title: "chore: Update EEA Files"
+        title: "chore: Update ${{ github.event.inputs.library && format('{0} ', github.event.inputs.library) || '' }}EEA files"
         author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
         committer: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
-        commit-message: "chore: Update EEA Files"
+        commit-message: "chore: Update EEA ${{ github.event.inputs.library && format('{0} ', github.event.inputs.library) || '' }}files"
         body: ${{ steps.eea_updates.outputs.updates }}
         add-paths: libraries
-        branch: eea_updates
+        branch: ${{ github.event.inputs.library && format('eea_{0}_updates', github.event.inputs.library) || 'eea_updates' }}
         delete-branch: true
         token: ${{ github.token }}


### PR DESCRIPTION
This change enables selective updates to the EEAs of a single library through a dedicated PR. It simplifies the review process for PRs involving the initial generation of EEA files.