### PR TITLE
ci: sign commits in PRs of updater

### DIFF
--- a/.github/workflows/update-eea-files.yml
+++ b/.github/workflows/update-eea-files.yml
@@ -130,6 +130,8 @@ jobs:
         author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
         committer: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
         commit-message: "chore: Update EEA ${{ github.event.inputs.library && format('{0} ', github.event.inputs.library) || '' }}files"
+        signoff: true
+        sign-commits: true
         body: ${{ steps.eea_updates.outputs.updates }}
         add-paths: libraries
         branch: ${{ github.event.inputs.library && format('eea_{0}_updates', github.event.inputs.library) || 'eea_updates' }}


### PR DESCRIPTION
This is required to be able to merge PRs created by the scheduled updater