### PR TITLE
Revert "ci: don't create PRs with GPG signed commits in updater workflow"

### DIFF
--- a/.github/workflows/update-eea-files.yml
+++ b/.github/workflows/update-eea-files.yml
@@ -131,6 +131,7 @@ jobs:
         committer: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
         commit-message: "chore: Update EEA ${{ github.event.inputs.library && format('{0} ', github.event.inputs.library) || '' }}files"
         signoff: true
+        sign-commits: true
         body: ${{ steps.eea_updates.outputs.updates }}
         add-paths: libraries
         branch: ${{ github.event.inputs.library && format('eea_{0}_updates', github.event.inputs.library) || 'eea_updates' }}


### PR DESCRIPTION
This reverts commit ce1d9f659dcda1793f755105e3f836b3b58d37f0.

We need the signed commits because of a branch protection rule that prevents merging otherwise.
